### PR TITLE
fix: use nested location block for nginx PHP handling

### DIFF
--- a/root/etc/nginx/conf.d/tinyfilemanager.locations
+++ b/root/etc/nginx/conf.d/tinyfilemanager.locations
@@ -1,33 +1,31 @@
-location = /tinyfilemanager/ {
-	fastcgi_split_path_info ^(.+?\.php)(/.*)$;
-	if (!-f $document_root$fastcgi_script_name) {
-		return 404;
+location /tinyfilemanager/ {
+	index index.php;
+
+	location ~ \.php$ {
+		# Mitigate https://httpoxy.org/ vulnerabilities
+		fastcgi_param HTTP_PROXY "";
+
+		#error_log /dev/null;
+		fastcgi_connect_timeout 300s;
+		fastcgi_read_timeout 300s;
+		fastcgi_send_timeout 300s;
+		fastcgi_buffer_size 32k;
+		fastcgi_buffers 4 32k;
+		fastcgi_busy_buffers_size 32k;
+		fastcgi_temp_file_write_size 32k;
+		client_body_timeout 10s;
+		send_timeout 60s; # default, increase if experiencing a lot of timeouts.
+		output_buffers 1 32k;
+		include fastcgi_params;
+
+		# Only throw it at PHP-FPM if file exists (prevents PHP exploits).
+		fastcgi_pass	127.0.0.1:1026;  # or: unix:/var/run/php-fpm.sock;
+		# fastcgi_pass	unix:/var/run/php8-fpm.sock;
+
+		# SCRIPT_FILENAME parameter is used for PHP FPM determining
+		#  the script name. If it is not set in fastcgi_params file,
+		# i.e. /etc/nginx/fastcgi_params or in the parent contexts,
+		# please comment off following line:
+		fastcgi_param  SCRIPT_FILENAME   $document_root$fastcgi_script_name;
 	}
-
-	# Mitigate https://httpoxy.org/ vulnerabilities
-	fastcgi_param HTTP_PROXY "";
-
-	#error_log /dev/null;
-	fastcgi_connect_timeout 300s;
-	fastcgi_read_timeout 300s;
-	fastcgi_send_timeout 300s;
-	fastcgi_buffer_size 32k;
-	fastcgi_buffers 4 32k;
-	fastcgi_busy_buffers_size 32k;
-	fastcgi_temp_file_write_size 32k;
-	client_body_timeout 10s;
-	send_timeout 60s; # default, increase if experiencing a lot of timeouts.
-	output_buffers 1 32k;
-	fastcgi_index index.php;
-	include fastcgi_params;
-
-	# Only throw it at PHP-FPM if file exists (prevents PHP exploits).
-	fastcgi_pass	127.0.0.1:1026;  # or: unix:/var/run/php-fpm.sock;
-	# fastcgi_pass	unix:/var/run/php8-fpm.sock;
-
-	# SCRIPT_FILENAME parameter is used for PHP FPM determining
-	#  the script name. If it is not set in fastcgi_params file,
-	# i.e. /etc/nginx/fastcgi_params or in the parent contexts,
-	# please comment off following line:
-	fastcgi_param  SCRIPT_FILENAME   $document_root$fastcgi_script_name;
 }


### PR DESCRIPTION
## Problem

The original `location = /tinyfilemanager/` uses exact match, which only handles the initial entry URL. When PHP returns a 302 redirect to `/tinyfilemanager/index.php?p=`, nginx cannot match it against the exact location, causing the `.php` file to be served as a static file (`application/octet-stream`) — the browser prompts to download `index.php` instead of rendering the page.

Additionally, static assets (CSS/JS/Fonts) under `/tinyfilemanager/assets/` were also not matched, leading to broken styles when the location was changed to a simple prefix match.

## Fix

Use a nested location structure:
- Outer `location /tinyfilemanager/` (prefix match) — catches all sub-paths, serves static files directly via nginx
- Inner `location ~ \.php$` (regex match) — routes only `.php` requests to PHP-FPM via fastcgi
- Added `index index.php` — auto-resolves `/tinyfilemanager/` to `index.php`

## Testing

Verified on OpenWrt device with nginx:
- `/tinyfilemanager/` → 200 `text/html` ✅
- `/tinyfilemanager/index.php?p=` → 200 `text/html` ✅
- `/tinyfilemanager/assets/css/bootstrap.min.css` → 200 `text/css` ✅
- `/tinyfilemanager/assets/js/bootstrap.bundle.min.js` → 200 `application/javascript` ✅
- `/tinyfilemanager/assets/fonts/fontawesome-webfont.woff2` → 200 `font/woff2` ✅

No impact on uhttpd environments (this file is only loaded by nginx).